### PR TITLE
Fail the Grunt task if dead links found

### DIFF
--- a/src/tasks/deadlink.coffee
+++ b/src/tasks/deadlink.coffee
@@ -14,6 +14,9 @@ module.exports = (grunt) ->
 
   grunt.registerMultiTask 'deadlink', 'check dead links in files.', ->
     done = @async()
+    fail = (failCount) ->
+      grunt.fail.warn("Found #{failCount} dead links")
+      @async()
 
     options = @options
       # this expression can changed to recognizing other url format.
@@ -45,4 +48,4 @@ module.exports = (grunt) ->
         logger.increaseLinkCount()
         checker.checkDeadlink filepath, link
 
-    logger.printResult done
+    logger.printResult done, fail

--- a/src/tasks/logger.coffee
+++ b/src/tasks/logger.coffee
@@ -53,12 +53,15 @@ module.exports = (grunt) ->
       @linkCount++
       @progressBar.total = @linkCount if @progressBar?
 
-    printResult: (after)->
+    printResult: (onSuccess, onFail)->
       st = setInterval =>
         if(@linkCount == (@okCount + @failCount + @passCount))
           @resultLogger "ok : #{@okCount}, error : #{@failCount}, pass : #{@passCount}"
           clearInterval st
-          after()
+          if @failCount == 0
+            onSuccess()
+          else
+            onFail(@failCount)
       , 500
 
   Logger


### PR DESCRIPTION
The Grunt task should fail if there are any dead links. 

Close issue #9 