### PR TITLE
Logging bug fix for logToFile option

### DIFF
--- a/src/tasks/logger.coffee
+++ b/src/tasks/logger.coffee
@@ -14,7 +14,7 @@ module.exports = (grunt) ->
     constructor : ({logToFile, logAll, logFilename}) ->
       @logFilename = logFilename if logFilename?
       if logToFile
-        @passCount = @resultLogger = @errorLogger = @okLogger = (msg) -> fs.appendFile @logFilename, msg + lineSeparator, (err)->
+        @passLogger = @resultLogger = @errorLogger = @okLogger = (msg) -> fs.appendFile @logFilename, msg + lineSeparator, (err)->
       if not logAll
         @okLogger = (str)->
         @passLogger = (str)->


### PR DESCRIPTION
Error found: With logToFile, the task never finishes.
Reason is that the linkcount never reaches the expected value because
passCount is NaN.